### PR TITLE
show introduction text

### DIFF
--- a/www/config.js
+++ b/www/config.js
@@ -3,6 +3,8 @@ var config = {
   language: 'en',
   // Show help text for images
   showHelp: true,
+  // Show Introduction text
+  showIntro: false,
   // Image overview file or path to the ASU API
   versions: {
     'SNAPSHOT': '../misc/snapshot/overview.json',

--- a/www/index.css
+++ b/www/index.css
@@ -90,6 +90,10 @@ header > div {
   color: #fff;
 }
 
+#intro {
+  display: none;
+}
+
 .container {
   padding-left: 1.2em;
   padding-right: 1.2em;

--- a/www/index.html
+++ b/www/index.html
@@ -52,6 +52,12 @@
 			<div id="buildstatus"></div>
 		</div>
 
+		<div id="intro">
+			<span class="tr-intro">
+				There are currently <span id="model-count">0</span> models from <span id="target-count">0</span> targets available.
+			</span>
+		</div>
+
 		<div id="images">
 			<div id="custom">
 				<h3 class="tr-customize">Customize</h3>

--- a/www/index.js
+++ b/www/index.js
@@ -303,6 +303,19 @@ function updatePackageList(version, target) {
   });
 }
 
+function updateIntro(obj) {
+  function count(array, key) {
+    var set = new Set();
+    for (var i = 0; i < array.length; i += 1) {
+      set.add(array[i][key]);
+    }
+    return set.size;
+  };
+  var entries = Object.values(obj['models'])
+  $('#model-count').innerText = entries.length;
+  $('#target-count').innerText = count(entries, 'target');
+}
+
 function updateImages(version, code, date, model, url, mobj, is_custom) {
   // add download button for image
   function addLink(type, file) {
@@ -391,8 +404,10 @@ function updateImages(version, code, date, model, url, mobj, is_custom) {
     }
 
     show('#images');
+    hide('#intro');
   } else {
     hide('#images');
+    show('#intro');
   }
 }
 
@@ -420,6 +435,7 @@ function init() {
       return obj
     })
     .then(obj => {
+      updateIntro(obj);
       setupAutocompleteList($('#models'), Object.keys(obj['models']), false, updateImages, models => {
         var model = models.value;
         if (model in obj['models']) {


### PR DESCRIPTION
Show some introduction text with the number of images and targets available.
This is mostly a placeholder to add custom text (e.g. what snapshot is and that the latest release is not old). 

This is disabled by default ("showIntro" setting).